### PR TITLE
Readme correction: python-basic corrected for archived python-intro repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ If you wish to run the course on your personal computer, here are the steps to f
 ## Clone this github project
 
 ```bash
-git clone https://github.com/pycam/python-intro.git
-cd python-intro
+git clone https://github.com/pycam/python-basic.git
+cd python-basic
 ```
 
 ## Dependencies


### PR DESCRIPTION
I've just came across this one and thought to correct straight away (unless I miss interpreted, then please ignore)